### PR TITLE
Show the calendar date for each puzzle

### DIFF
--- a/sharesite/templates/sharesite/day_browser.html
+++ b/sharesite/templates/sharesite/day_browser.html
@@ -11,3 +11,8 @@
 		<a href="?day={{day|add:"1"}}" class="text-4xl ml-3" alt="Next day" title="Next day">&gt;</a>
 	{% endif %}
 </div>
+<div class="flex flex-row justify-center items-center text-sm">
+	{%- assign epoch = "2021-06-19 12:00" -%}
+	{%- assign offset = day | times: 86400 -%}
+	{{ epoch | add: offset | date: "%A %e %B %Y" }}
+</div>


### PR DESCRIPTION
It's hard enough keeping track of dates these days, and the Wordle Calendar System doesn't care.

Uses an epoch of 12:00 server time on Day 0 (2021-06-19) to avoid the worst of the possible timezone edge cases.